### PR TITLE
Add flexible width card class to prevent word wrapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
 						<figcaption class="visually-hidden">Photo of Rudzainy looking to the side.</figcaption>
 					</figure>
 				</article>
-				<article class="card border border-primary">
+				<article class="card card-title-intro border border-primary">
 					<div class="card-body">
 						<h1 class="card-title text-primary" style="--bs-text-opacity: .7"><span>i am </span>Rudzainy Rahman</h1>
 					</div>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
 						<figcaption class="visually-hidden">Photo of Rudzainy looking to the side.</figcaption>
 					</figure>
 				</article>
-				<article class="card card-title-intro border border-primary">
+				<article class="card card-width-fit border border-primary">
 					<div class="card-body">
 						<h1 class="card-title text-primary" style="--bs-text-opacity: .7"><span>i am </span>Rudzainy Rahman</h1>
 					</div>

--- a/si-es-es.css
+++ b/si-es-es.css
@@ -446,6 +446,19 @@ button:focus-visible,
   color: rgba(255, 255, 255, 0.6);
 }
 
+/* Flexible width card for title/intro - prevents word wrapping */
+section:not(.grid-container) > article.card.card-title-intro {
+  width: fit-content;
+  min-width: var(--card-base-size);
+  max-width: 100%;
+}
+
+section:not(.grid-container) > article.card.card-title-intro .card-title {
+  word-break: keep-all;
+  overflow-wrap: normal;
+  hyphens: none;
+}
+
 /* Section-specific content heading colors */
 /* Life posts - green headings */
 body:has(.page-header-life) main h2,

--- a/si-es-es.css
+++ b/si-es-es.css
@@ -446,14 +446,14 @@ button:focus-visible,
   color: rgba(255, 255, 255, 0.6);
 }
 
-/* Flexible width card for title/intro - prevents word wrapping */
-section:not(.grid-container) > article.card.card-title-intro {
+/* Flexible width card - prevents word wrapping */
+section:not(.grid-container) > article.card.card-width-fit {
   width: fit-content;
   min-width: var(--card-base-size);
   max-width: 100%;
 }
 
-section:not(.grid-container) > article.card.card-title-intro .card-title {
+section:not(.grid-container) > article.card.card-width-fit .card-title {
   word-break: keep-all;
   overflow-wrap: normal;
   hyphens: none;


### PR DESCRIPTION
Add card-title-intro class that allows cards to expand width based on
content while preventing individual words from breaking. The sentence
can still wrap to multiple lines, but words like "Rudzainy" will stay
intact.