### PR TITLE
Replace Jekyll responsive_image tags with HTML img elements

### DIFF
--- a/balance/2003-08-28-family.html
+++ b/balance/2003-08-28-family.html
@@ -64,8 +64,8 @@
 
 <p>Guess which one is me ^.^</p>
 
-<p>{ % responsive_image path: assets/img/posts/family___1<em>by_rudzainy07_d1ox7h-375w-2x.jpeg alt: “Lineart in pencil. Inked with technical pens” %}
-_Lineart in pencil. Inked with technical pens</em></p>
+<p><img src="/assets/img/posts/family___1_by_rudzainy07_d1ox7h-375w-2x.jpeg" alt="Lineart in pencil. Inked with technical pens" class="img-fluid">
+<em>Lineart in pencil. Inked with technical pens</em></p>
 
 <p>Originally posted <a href="https://www.deviantart.com/rudzainy07/art/family-1-2842397">on DeviantArt</a></p>
 

--- a/balance/2009-08-24-tm-parody-ad.html
+++ b/balance/2009-08-24-tm-parody-ad.html
@@ -81,7 +81,7 @@
   </tbody>
 </table>
 
-<p>{ % responsive_image path: assets/img/posts/10400376_132225319544_8304899_n.jpeg alt: “A parody adveritisement for TM.” %}
+<p><img src="/assets/img/posts/10400376_132225319544_8304899_n.jpeg" alt="A parody adveritisement for TM." class="img-fluid">
 <em>A parody adveritisement for TM.</em></p>
 
 <p>“Hubungi mereka yang tersayang dari pondok telefon TM”</p>

--- a/balance/2016-05-19-browsercrush-clone.html
+++ b/balance/2016-05-19-browsercrush-clone.html
@@ -91,7 +91,7 @@
 
 <p>Built using Ruby, HTML, CSS and Javascript.</p>
 
-<p>{ % responsive_image path: assets/img/posts/browsercrush_clone.gif alt: “A gameplay of my Browser Crush Clone game.” %}
+<p><img src="/assets/img/posts/browsercrush_clone.gif" alt="A gameplay of my Browser Crush Clone game." class="img-fluid">
 <em>A gameplay of my Browser Crush Clone game.</em></p>
 
 <h2 id="setup">Setup</h2>

--- a/balance/2016-09-01-kontact-web-crm-system.html
+++ b/balance/2016-09-01-kontact-web-crm-system.html
@@ -85,10 +85,10 @@
 
 <p>I built this heat level indicator for each contact. It was supposed to indicate to the CRM users how <em>“hot”</em> is that particular contact by means of profiling.</p>
 
-<p>{ % responsive_image path: assets/img/portfolio/kontact-app-1.png alt: “A contact page expanded to show contacts history and details.” %}
+<p><img src="/assets/img/portfolio/kontact-app-1.png" alt="A contact page expanded to show contacts history and details." class="img-fluid">
 <em>A contact page expanded to show contacts history and details.</em></p>
 
-<p>{ % responsive_image path: assets/img/posts/Screenshot_2023-12-25_at_8-48-43_PM.png alt: “The heat map uses an algorithm to help users make decisions on when to get in touch with their contacts.” %}
+<p><img src="/assets/img/posts/Screenshot_2023-12-25_at_8-48-43_PM.png" alt="The heat map uses an algorithm to help users make decisions on when to get in touch with their contacts." class="img-fluid">
 <em>The heat map uses an algorithm to help users make decisions on when to get in touch with their contacts.</em></p>
 
 

--- a/balance/2019-04-24-orang-kasar.html
+++ b/balance/2019-04-24-orang-kasar.html
@@ -89,7 +89,7 @@
   </tbody>
 </table>
 
-<p>{ % responsive_image path: assets/img/posts/70749792_10156914013949545_8267946219578327040_n.jpeg alt: “Poster Orang Kasar.” %}
+<p><img src="/assets/img/posts/70749792_10156914013949545_8267946219578327040_n.jpeg" alt="Poster Orang Kasar." class="img-fluid">
 <em>Poster Orang Kasar.</em></p>
 
 <h2 id="retrospective">Retrospective:</h2>

--- a/balance/2023-12-23-ranting.html
+++ b/balance/2023-12-23-ranting.html
@@ -72,23 +72,23 @@
 
 <p>Malaysians are (in general) very adaptive when it comes to digital technology adoption. This is true especially for global internet trends – for example social media platforms (Friendster, WhatsApp, Instagram, Spotify, YouTube), digital marketing and SEO tools (Google Ads, Google Analytics, various local digital ads companies), peer-to-peer or crowdsourcing tools (Google Maps, various online document sharing services) and general online tools (Bitly, Google Workspace apps, GitHub, GMail). This is mainly thanks to Malaysia’s internet infrastructure.</p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/Screenshot_2024-05-02<em>at_8-50-03_AM.png alt: “Timeline of mobile cellular service adoption in Malaysia, with 3G expansion giving access to the internet through people’s fingertips – A Glance at Malaysia’s Digital Connectivity Journey, MCMC.” %}
-_Timeline of mobile cellular service adoption in Malaysia, with 3G expansion giving access to the internet through people’s fingertips – <a href="/assets/pdf/Insight-Digital-Connectivity.pdf">A Glance at Malaysia’s Digital Connectivity Journey, MCMC</a>.</em></p>
+<p><img src="/assets/img/posts/ranting/Screenshot_2024-05-02_at_8-50-03_AM.png" alt="Timeline of mobile cellular service adoption in Malaysia, with 3G expansion giving access to the internet through people's fingertips – A Glance at Malaysia's Digital Connectivity Journey, MCMC." class="img-fluid">
+<em>Timeline of mobile cellular service adoption in Malaysia, with 3G expansion giving access to the internet through people's fingertips – <a href="/assets/pdf/Insight-Digital-Connectivity.pdf">A Glance at Malaysia's Digital Connectivity Journey, MCMC</a>.</em></p>
 
 <p>Malaysia ranks 37th out of 121 countries in the Digital Quality of Life Index and 13th in internet quality with stable mobile internet connections, improved transmission speeds, and fixed internet stability.</p>
 
 <p>“The number of internet users in Malaysia was forecast to continuously increase between 2024 and 2029 by in total 1.7 million users (+5 percent). After the fifteenth consecutive increasing year, the number of users is estimated to reach 35.65 million users and therefore a new peak in 2029.” – <a href="https://www.statista.com/statistics/553752/number-of-internet-users-in-malaysia/#:~:text=The%20number%20of%20internet%20users,a%20new%20peak%20in%202029.">Statista</a></p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/number-of-internet-users-in-Malaysia-2014-2029.png alt: “Forecast number of internet users in Malaysia from 2014-2029.” %}
+<p><img src="/assets/img/posts/ranting/number-of-internet-users-in-Malaysia-2014-2029.png" alt="Forecast number of internet users in Malaysia from 2014-2029." class="img-fluid">
 <em>Forecast number of internet users in Malaysia from 2014-2029.</em></p>
 
 <p>This, combined with a steady increase in population, creates a consistant supply of digital natives who rely on smartphones for thier daily activities.</p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/Screenshot_2024-05-12<em>at_10-29-44_AM.png alt: “Population growth rate in Malaysia from 1971 - 2023 reveals a slight downtrend for four decades before a sudden spike in the early 2010s, and back down again.” %}
-_Population growth rate in Malaysia from 1971 - 2023 reveals a slight downtrend for four decades before a sudden spike in the early 2010s, and back down again.</em></p>
+<p><img src="/assets/img/posts/ranting/Screenshot_2024-05-12_at_10-29-44_AM.png" alt="Population growth rate in Malaysia from 1971 - 2023 reveals a slight downtrend for four decades before a sudden spike in the early 2010s, and back down again." class="img-fluid">
+<em>Population growth rate in Malaysia from 1971 - 2023 reveals a slight downtrend for four decades before a sudden spike in the early 2010s, and back down again.</em></p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/Screenshot_2024-05-12<em>at_10-31-17_AM.png alt: “Total population of Malaysia still increases year-to-year, with the recent negative growth rate (from the chart above) only slightly impacted the total population growth.” %}
-_Total population of Malaysia still increases year-to-year, with the recent negative growth rate (from the chart above) only slightly impacted the total population growth.</em></p>
+<p><img src="/assets/img/posts/ranting/Screenshot_2024-05-12_at_10-31-17_AM.png" alt="Total population of Malaysia still increases year-to-year, with the recent negative growth rate (from the chart above) only slightly impacted the total population growth." class="img-fluid">
+<em>Total population of Malaysia still increases year-to-year, with the recent negative growth rate (from the chart above) only slightly impacted the total population growth.</em></p>
 
 <p>in June 2021, the Government of Malaysia approved the recognition of <em>communications as a public utility</em>, after water and electricity. This resulted in an increase in internet penetration in some of the most remote parts in the country, thanks to local telecommunications companies providing satellite internet services. And in November 2023, Starlink (the global satellite-based high-speed internet service provider) extends it’s coverage to Malaysia.</p>
 
@@ -100,7 +100,7 @@ _Total population of Malaysia still increases year-to-year, with the recent nega
 
 <p>I imagine a framework on how Malaysians can communicate better.</p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/sketch.png alt: “Rough idea of a digital communication framework that has the potential to check a bunch of boxes.” %}
+<p><img src="/assets/img/posts/ranting/sketch.png" alt="Rough idea of a digital communication framework that has the potential to check a bunch of boxes." class="img-fluid">
 <em>Rough idea of a digital communication framework that has the potential to check a bunch of boxes.</em></p>
 
 <p>Seems like a problem too big for one man lulz. I decided to start with Biodata. Biodata has the advantages of being easy to build from scratch as well as cheap to run, compared to other components of the framework.</p>
@@ -140,14 +140,14 @@ _Total population of Malaysia still increases year-to-year, with the recent nega
 
 <p>When exploring what can people use links for, I received multiple feedbacks to connect the links with real-world usage. Over time, I decided to base Ranting on Bitly’s model instead – a profile page, link shortener and QR code generator.</p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/Screenshot_2024-04-30<em>at_1-55-58_PM.png alt: “Current state of Ranting’s entity relationship diagram.” %}
-_Current state of Ranting’s entity relationship diagram.</em></p>
+<p><img src="/assets/img/posts/ranting/Screenshot_2024-04-30_at_1-55-58_PM.png" alt="Current state of Ranting's entity relationship diagram." class="img-fluid">
+<em>Current state of Ranting's entity relationship diagram.</em></p>
 
 <p>Considering future expansions, I introduced a Groups table as a mean to manage and distribute a collection of links, tho this feature is still in WIP.</p>
 
 <p>Analytics also was a huge ask from the feedback gathered. <a href="https://twitter.com/hewrin_10">Faris the Backend-Man™</a> helped to set up a feature to capture pageviews and clicks on our links.</p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/analytics.png alt: “Users can view total unique visitors and page views count.” %}
+<p><img src="/assets/img/posts/ranting/analytics.png" alt="Users can view total unique visitors and page views count." class="img-fluid">
 <em>Users can view total unique visitors and page views count.</em></p>
 
 <h2 id="information-design">Information Design</h2>
@@ -179,11 +179,11 @@ User
 
 <p>Ranting uses <a href="https://getbootstrap.com">Bootstrap</a> for almost all it’s UI needs. I stumbled upon <a href="https://bento.me">Bento</a> while doing my research and was inspired to build the same cool UI.</p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/design_components.png alt: “Samples of design components.” %}
+<p><img src="/assets/img/posts/ranting/design_components.png" alt="Samples of design components." class="img-fluid">
 <em>Samples of design components.</em></p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/concept.png alt: “Initial concept for Ranting’s user Profile Page.” %}
-<em>Initial concept for Ranting’s user Profile Page.</em></p>
+<p><img src="/assets/img/posts/ranting/concept.png" alt="Initial concept for Ranting's user Profile Page." class="img-fluid">
+<em>Initial concept for Ranting's user Profile Page.</em></p>
 
 <h3 id="ui-framework">UI framework</h3>
 
@@ -210,7 +210,7 @@ User
 
 <p>Upon hitting the limitations of Bootstrap Icons, I expanded my icons library with Font Awesome!</p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/Login-Mobile.png alt: “Design of mobile login page in Figma using Bootstrap 5 design components.” %}
+<p><img src="/assets/img/posts/ranting/Login-Mobile.png" alt="Design of mobile login page in Figma using Bootstrap 5 design components." class="img-fluid">
 <em>Design of mobile login page in Figma using Bootstrap 5 design components.</em></p>
 
 <h3 id="branding">Branding</h3>
@@ -219,8 +219,8 @@ User
 
 <p>All of this to save time!</p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/bootstrap-logo-ranting.png alt: “Ranting’s logo directly plagiarizing Bootstrap’s logo.” %}
-<em>Ranting’s logo based on Bootstrap’s logo.</em></p>
+<p><img src="/assets/img/posts/ranting/bootstrap-logo-ranting.png" alt="Ranting's logo directly plagiarizing Bootstrap's logo." class="img-fluid">
+<em>Ranting's logo based on Bootstrap's logo.</em></p>
 
 <p>When I had to rebrand Ranting (more on this <a href="#re-branding">below</a>), I initially considered a few options:</p>
 
@@ -232,7 +232,7 @@ User
 
 <p>I ended up purchasing an entirely new domain called gugel.my and got to work.</p>
 
-<p>{ % responsive_image path: assets/img/posts/yolo.gif alt: “YOLO.” %}
+<p><img src="/assets/img/posts/yolo.gif" alt="YOLO." class="img-fluid">
 <em>YOLO.</em></p>
 
 <p>The rebranding process was quite straight forward.</p>
@@ -243,11 +243,11 @@ User
   <li>Find &amp; replace all Ranting text with Gugel in the app 🏆.</li>
 </ol>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/bootstrap-logo-gugel.png alt: “Gugel’s logo directly plagiarizing Bootstrap’s logo.” %}
-<em>Gugel’s logo based on Bootstrap’s logo.</em></p>
+<p><img src="/assets/img/posts/ranting/bootstrap-logo-gugel.png" alt="Gugel's logo directly plagiarizing Bootstrap's logo." class="img-fluid">
+<em>Gugel's logo based on Bootstrap's logo.</em></p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/navbar-brand.png alt: “Design variants of Gugel’s logo.” %}
-<em>Design variants of Gugel’s logo.</em></p>
+<p><img src="/assets/img/posts/ranting/navbar-brand.png" alt="Design variants of Gugel's logo." class="img-fluid">
+<em>Design variants of Gugel's logo.</em></p>
 
 <p>I decided to expose the top level domain <code>.my</code> in the full logo to increase probability of people remembering Gugel’s URL.</p>
 
@@ -268,13 +268,13 @@ User
   &lt;% end %&gt;
 </code></p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/gugel_logo.png alt: “Snapshot of Gugel’s actual logo from the code above.” %}
-<em>Snapshot of Gugel’s actual logo from the code above.</em></p>
+<p><img src="/assets/img/posts/ranting/gugel_logo.png" alt="Snapshot of Gugel's actual logo from the code above." class="img-fluid">
+<em>Snapshot of Gugel's actual logo from the code above.</em></p>
 
 <h3 id="user-journeys">User journeys</h3>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/Screenshot_2024-04-30<em>at_2-19-22_PM.png alt: “User journey for Short Links feature.” %}
-_User journey for Short Links feature.</em></p>
+<p><img src="/assets/img/posts/ranting/Screenshot_2024-04-30_at_2-19-22_PM.png" alt="User journey for Short Links feature." class="img-fluid">
+<em>User journey for Short Links feature.</em></p>
 
 <h2 id="challenges">Challenges</h2>
 
@@ -292,45 +292,45 @@ _User journey for Short Links feature.</em></p>
 
 <p>The project went through a lot of discussions and considerations while in development.</p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/V1-Page-Link-button-Image-upload-Link-group.jpg alt: “V1.” %}
+<p><img src="/assets/img/posts/ranting/V1-Page-Link-button-Image-upload-Link-group.jpg" alt="V1." class="img-fluid">
 <em>V1.</em></p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/V2-Manage-children-page-Bento-link-button.jpg alt: “V2.” %}
+<p><img src="/assets/img/posts/ranting/V2-Manage-children-page-Bento-link-button.jpg" alt="V2." class="img-fluid">
 <em>V2.</em></p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/V3-Scheduler-Payment.jpg alt: “V3.” %}
+<p><img src="/assets/img/posts/ranting/V3-Scheduler-Payment.jpg" alt="V3." class="img-fluid">
 <em>V3.</em></p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/V4-1-Members-Signed-out.jpg alt: “V4-1.” %}
+<p><img src="/assets/img/posts/ranting/V4-1-Members-Signed-out.jpg" alt="V4-1." class="img-fluid">
 <em>V4-1.</em></p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/V4-2-Members-Signed-in.jpg alt: “V4-2.” %}
+<p><img src="/assets/img/posts/ranting/V4-2-Members-Signed-in.jpg" alt="V4-2." class="img-fluid">
 <em>V4-2.</em></p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/V5-Messaging.jpg alt: “V5.” %}
+<p><img src="/assets/img/posts/ranting/V5-Messaging.jpg" alt="V5." class="img-fluid">
 <em>V5.</em></p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/Screenshot_2023-12-23<em>at_11-44-15_PM.png alt: “Work in progress of user links page.” %}
-_Work in progress of user links page.</em></p>
+<p><img src="/assets/img/posts/ranting/Screenshot_2023-12-23_at_11-44-15_PM.png" alt="Work in progress of user links page." class="img-fluid">
+<em>Work in progress of user links page.</em></p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/Screenshot_2023-09-29<em>at_3-37-28_PM.png alt: “Work in progress of user links page.” %}
-_Work in progress of user links page.</em></p>
+<p><img src="/assets/img/posts/ranting/Screenshot_2023-09-29_at_3-37-28_PM.png" alt="Work in progress of user links page." class="img-fluid">
+<em>Work in progress of user links page.</em></p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/Screenshot_2023-09-29<em>at_3-39-30_PM.png alt: “Work in progress of user links page.” %}
-_Work in progress of user links page.</em></p>
+<p><img src="/assets/img/posts/ranting/Screenshot_2023-09-29_at_3-39-30_PM.png" alt="Work in progress of user links page." class="img-fluid">
+<em>Work in progress of user links page.</em></p>
 
 <p>Building the drag and drop feature and fine tuning them to behave exactly how I want takes more effort than I anticipated. I was using DragDropTouch.js in which to make the experience as mobile-first as possible for a web app. Unfortunately the library introduced some weird behaviours on iOS devices. Therefore for version 1.0.0 and until 1.1.0, Ranting will focus to deliver simple and practical UI without the fancy drag adn drop functionality 😔.</p>
 
-<p>{ % responsive_image path: assets/img/posts/overcome.png alt: “An approach to solving problems.” %}
+<p><img src="/assets/img/posts/overcome.png" alt="An approach to solving problems." class="img-fluid">
 <em>An approach to solving problems</em> 😂.</p>
 
 <h2 id="yet-to-be-concluded">Yet To Be Concluded</h2>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/Screenshot_2024-05-09<em>at_4-35-59_PM.png alt: “They (requirements) grow up so fast…” %}
-_They (requirements) grow up so fast…</em></p>
+<p><img src="/assets/img/posts/ranting/Screenshot_2024-05-09_at_4-35-59_PM.png" alt="They (requirements) grow up so fast…" class="img-fluid">
+<em>They (requirements) grow up so fast…</em></p>
 
-<p>{ % responsive_image path: assets/img/posts/ranting/use_case.png alt: “Artist’s impression of how user’s profile page could look like.” %}
-<em>Artist’s impression of how user’s profile page could look like.</em></p>
+<p><img src="/assets/img/posts/ranting/use_case.png" alt="Artist's impression of how user's profile page could look like." class="img-fluid">
+<em>Artist's impression of how user's profile page could look like.</em></p>
 
 <p>This project is still in progress.</p>
 

--- a/life/2018-02-25-snapshot_of_website.html
+++ b/life/2018-02-25-snapshot_of_website.html
@@ -87,7 +87,7 @@
 
 <p>Old design of rudzainy.com built with HTML, CSS and JavaScript.</p>
 
-<p>{ % responsive_image path: assets/img/posts/rudzainy_dot_com_old.gif alt: “Old design of rudzainy.com built with HTML, CSS and JavaScript.” %}
+<p><img src="/assets/img/posts/rudzainy_dot_com_old.gif" alt="Old design of rudzainy.com built with HTML, CSS and JavaScript." class="img-fluid">
 <em>Old design of rudzainy.com built with HTML, CSS and JavaScript.</em></p>
 
 			</article>

--- a/work/2011-09-01-malaysia-maritime-association-logo-website.html
+++ b/work/2011-09-01-malaysia-maritime-association-logo-website.html
@@ -85,7 +85,7 @@
   </tbody>
 </table>
 
-<p>{ % responsive_image path: assets/img/portfolio/Maritime/MMA-logo.png alt: “Logo of Malaysian Maritime Association” %}
+<p><img src="/assets/img/portfolio/Maritime/MMA-logo.png" alt="Logo of Malaysian Maritime Association" class="img-fluid">
 <em>Logo of Malaysian Maritime Association</em></p>
 
 <p>The logo encapsulates various maritime symbols, underscoring its seafaring essence.</p>
@@ -96,7 +96,7 @@
 
 <p>At the heart of the logo, the North Star serves as a poignant reminder of the association’s mission—a guiding light for members navigating uncertain waters.</p>
 
-<p>{ % responsive_image path: assets/img/portfolio/Maritime/PEMM.jpg alt: “Website of Malaysian Maritime Association” %}
+<p><img src="/assets/img/portfolio/Maritime/PEMM.jpg" alt="Website of Malaysian Maritime Association" class="img-fluid">
 <em>Website of Malaysian Maritime Association</em></p>
 
 <p>The website was built on Joomla. I used a political theme template and did all end-to-end development for the website. My tasks includes, but not limited to, producing graphics and copywriting, developing the sitemap and information architecture, funneling leads to MMA’s Facebook page, managing deployment as well as setting up analytic tools.</p>

--- a/work/2012-09-01-maritime-college-corporate-branding.html
+++ b/work/2012-09-01-maritime-college-corporate-branding.html
@@ -81,7 +81,7 @@
   </tbody>
 </table>
 
-<p>{ % responsive_image path: assets/img/portfolio/Maritime/MARCO.jpg alt: “Maritime College Corporate Branding” %}
+<p><img src="/assets/img/portfolio/Maritime/MARCO.jpg" alt="Maritime College Corporate Branding" class="img-fluid">
 <em>Maritime College Corporate Branding</em></p>
 
 			</article>

--- a/work/2017-09-01-design-review-jkm-web-portal.html
+++ b/work/2017-09-01-design-review-jkm-web-portal.html
@@ -60,8 +60,8 @@
 		<main class="container my-5">
 			<article class="post-content">
 				
-<p>{ % responsive_image path: assets/img/portfolio/jkm.jpg alt: “An old version of JKM’s web portal.” %}
-<em>An old version of JKM’s web portal.</em></p>
+<p><img src="/assets/img/portfolio/jkm.jpg" alt="An old version of JKM's web portal." class="img-fluid">
+<em>An old version of JKM's web portal.</em></p>
 
 <p>In 2008, a younger me joined a local web development company as a web designer. He was just starting out in his career and had only just begun to explore the world of web design and development. His general role was to design UI and convert it to HTML &amp; CSS. At that time, web development using open source CMS was on the rise in Malaysia. PHP and WAMP/LAMP stacks were popular backend solutions, and Joomla! 1.5 was the most commonly used content management system (CMS). The company did not have any other designers on staff, so he worked closely with the developers and other stakeholders to design and build the web portal.</p>
 
@@ -93,7 +93,7 @@ Conclusion</p>
 
 <h2 id="recommendations">Recommendations</h2>
 
-<p>{ % responsive_image path: assets/img/portfolio/Screenshot-2022-01-27-at-2-47-23-PM-1024x774.jpeg alt: “Sketch of proposed solution for JKM web portal review.” %}
+<p><img src="/assets/img/portfolio/Screenshot-2022-01-27-at-2-47-23-PM-1024x774.jpeg" alt="Sketch of proposed solution for JKM web portal review." class="img-fluid">
 <em>Sketch of proposed solution for JKM web portal review.</em></p>
 
 <p>I recommend that the JKM website be updated to address the following issues:</p>
@@ -112,7 +112,7 @@ Conclusion</p>
 
 <p>I believe that these changes will make the JKM website even more user-friendly and accessible.</p>
 
-<p>{ % responsive_image path: assets/img/portfolio/Web-1280-1.png alt: “Low fedility design of proposed solution for JKM web portal review.” %}
+<p><img src="/assets/img/portfolio/Web-1280-1.png" alt="Low fedility design of proposed solution for JKM web portal review." class="img-fluid">
 <em>Low fedility design of proposed solution for JKM web portal review.</em></p>
 
 			</article>

--- a/work/2017-09-01-eezeejob.html
+++ b/work/2017-09-01-eezeejob.html
@@ -81,13 +81,13 @@
   </tbody>
 </table>
 
-<p>{ % responsive_image path: assets/img/portfolio/eezeejob/eezeejob.png alt: “Final design.” %}
+<p><img src="/assets/img/portfolio/eezeejob/eezeejob.png" alt="Final design." class="img-fluid">
 <em>Final design.</em></p>
 
-<p>{ % responsive_image path: assets/img/portfolio/eezeejob/Screen-Shot-2018-05-14-at-1-03-42-PM.png alt: “Wireframes.” %}
+<p><img src="/assets/img/portfolio/eezeejob/Screen-Shot-2018-05-14-at-1-03-42-PM.png" alt="Wireframes." class="img-fluid">
 <em>Wireframes.</em></p>
 
-<p>{ % responsive_image path: assets/img/portfolio/eezeejob/IMG_2256-768x1024.jpeg alt: “Sketches.” %}
+<p><img src="/assets/img/portfolio/eezeejob/IMG_2256-768x1024.jpeg" alt="Sketches." class="img-fluid">
 <em>Sketches.</em></p>
 
 			</article>

--- a/work/2017-09-01-next-academy-learning-portal.html
+++ b/work/2017-09-01-next-academy-learning-portal.html
@@ -86,10 +86,10 @@
   </tbody>
 </table>
 
-<p>{ % responsive_image path: assets/img/portfolio/na-lp-wireframe_draft.png alt: “Sitemap of the learning portal.” %}
+<p><img src="/assets/img/portfolio/na-lp-wireframe_draft.png" alt="Sitemap of the learning portal." class="img-fluid">
 <em>Sitemap of the learning portal.</em></p>
 
-<p>{ % responsive_image path: assets/img/portfolio/na-lp.png alt: “Finished UI of Next Academy Learning Portal.” %}
+<p><img src="/assets/img/portfolio/na-lp.png" alt="Finished UI of Next Academy Learning Portal." class="img-fluid">
 <em>Finished UI of Next Academy Learning Portal.</em></p>
 
 			</article>

--- a/work/2018-09-01-lkim-fish-price-app.html
+++ b/work/2018-09-01-lkim-fish-price-app.html
@@ -87,13 +87,13 @@
 
 <p>Worked in a team to design and develop a price check mobile app.</p>
 
-<p>{ % responsive_image path: assets/img/portfolio/lkim/Screenshot-2022-01-27-at-3-11-13-PM-1-1024x445.jpeg alt: “Mockup design of LKIM Fish Price app.” %}
+<p><img src="/assets/img/portfolio/lkim/Screenshot-2022-01-27-at-3-11-13-PM-1-1024x445.jpeg" alt="Mockup design of LKIM Fish Price app." class="img-fluid">
 <em>Mockup design of LKIM Fish Price app.</em></p>
 
-<p>{ % responsive_image path: assets/img/portfolio/lkim/Screenshot-2022-01-27-at-3-14-21-PM-1024x668.jpeg alt: “UI sketches fo LKIM Fish Price app.” %}
+<p><img src="/assets/img/portfolio/lkim/Screenshot-2022-01-27-at-3-14-21-PM-1024x668.jpeg" alt="UI sketches fo LKIM Fish Price app." class="img-fluid">
 <em>UI sketches fo LKIM Fish Price app.</em></p>
 
-<p>{ % responsive_image path: assets/img/portfolio/lkim/21462649_10155102992728460_2795738114477470255_n.jpeg alt: “The team working on the app.” %}
+<p><img src="/assets/img/portfolio/lkim/21462649_10155102992728460_2795738114477470255_n.jpeg" alt="The team working on the app." class="img-fluid">
 <em>The team working on the app.</em></p>
 
 			</article>

--- a/work/2018-09-01-postco-email-design.html
+++ b/work/2018-09-01-postco-email-design.html
@@ -81,13 +81,13 @@
   </tbody>
 </table>
 
-<p>{ % responsive_image path: assets/img/portfolio/postco/Users_rudzainy_Google20Drive_PostCo_Mails_postco_mail_collection_arrive.png alt: “Sample email design for PostCo.” %}
+<p><img src="/assets/img/portfolio/postco/Users_rudzainy_Google20Drive_PostCo_Mails_postco_mail_collection_arrive.png" alt="Sample email design for PostCo." class="img-fluid">
 <em>Sample email design for PostCo.</em></p>
 
-<p>{ % responsive_image path: assets/img/portfolio/postco/Users_rudzainy_Google20Drive_PostCo_Mails_postco_mail_return_returned.png alt: “Another sample email design for PostCo.” %}
+<p><img src="/assets/img/portfolio/postco/Users_rudzainy_Google20Drive_PostCo_Mails_postco_mail_return_returned.png" alt="Another sample email design for PostCo." class="img-fluid">
 <em>Another sample email design for PostCo.</em></p>
 
-<p>{ % responsive_image path: assets/img/portfolio/postco/Screenshot-2022-01-27-at-2-43-02-PM-730x1024.jpeg alt: “Sketch of proposed solution for map popup.” %}
+<p><img src="/assets/img/portfolio/postco/Screenshot-2022-01-27-at-2-43-02-PM-730x1024.jpeg" alt="Sketch of proposed solution for map popup." class="img-fluid">
 <em>Sketch of proposed solution for map popup.</em></p>
 
 			</article>

--- a/work/2024-05-26-ux-assignment-1.html
+++ b/work/2024-05-26-ux-assignment-1.html
@@ -82,14 +82,14 @@
 
 <p><a href="https://www.carpentersshipping.com/">Website of Carenters Shipping</a></p>
 
-<p>{ % responsive_image path: assets/img/portfolio/assignments/CarpentersShipping.png alt: “My take on the UI design for Carpenters Shipping website.” %}
+<p><img src="/assets/img/portfolio/assignments/CarpentersShipping.png" alt="My take on the UI design for Carpenters Shipping website." class="img-fluid">
 <em>My take on the UI design for Carpenters Shipping website.</em></p>
 
 <h2 id="industrial-and-maritime-engineering-limited-imel">Industrial and Maritime Engineering Limited (IMEL)</h2>
 
 <p><a href="https://imel.com.fj/">Website of IMEL</a></p>
 
-<p>{ % responsive_image path: assets/img/portfolio/assignments/IMEL.png alt: “My take on the UI design for International Maritime and Engineering Limited website.” %}
+<p><img src="/assets/img/portfolio/assignments/IMEL.png" alt="My take on the UI design for International Maritime and Engineering Limited website." class="img-fluid">
 <em>My take on the UI design for Industrial and Maritime Engineering Limited website.</em></p>
 
 <h2 id="retrospective">Retrospective</h2>

--- a/work/2025-07-26-ux-assignment-1.html
+++ b/work/2025-07-26-ux-assignment-1.html
@@ -82,14 +82,14 @@
 
 <p><a href="https://www.carpentersshipping.com/">Website of Carenters Shipping</a></p>
 
-<p>{ % responsive_image path: assets/img/portfolio/assignments/CarpentersShipping.png alt: “My take on the UI design for Carpenters Shipping website.” %}
+<p><img src="/assets/img/portfolio/assignments/CarpentersShipping.png" alt="My take on the UI design for Carpenters Shipping website." class="img-fluid">
 <em>My take on the UI design for Carpenters Shipping website.</em></p>
 
 <h2 id="industrial-and-maritime-engineering-limited-imel">Industrial and Maritime Engineering Limited (IMEL)</h2>
 
 <p><a href="https://imel.com.fj/">Website of IMEL</a></p>
 
-<p>{ % responsive_image path: assets/img/portfolio/assignments/IMEL.png alt: “My take on the UI design for International Maritime and Engineering Limited website.” %}
+<p><img src="/assets/img/portfolio/assignments/IMEL.png" alt="My take on the UI design for International Maritime and Engineering Limited website." class="img-fluid">
 <em>My take on the UI design for Industrial and Maritime Engineering Limited website.</em></p>
 
 <h2 id="retrospective">Retrospective</h2>


### PR DESCRIPTION
Convert Jekyll responsive_image syntax to proper HTML img tags
across 16 HTML files in work/, life/, and balance/ directories.
Images now use img-fluid class for Bootstrap responsive behavior.
Also fixed malformed paths where <em> tags were incorrectly inserted.